### PR TITLE
feat: rename packages and add publish configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "npm run build --workspace=odm && npm run build --workspace=odm",
-    "clean": "npm run clean --workspaces"
+    "build": "npm run build --workspace=mv-odm && npm run build --workspace=mv-odm-backend",
+    "clean": "npm run clean --workspaces",
+    "publish": "npm run build && npm publish --workspace=mv-odm-backend && npm publish --workspace=mv-odm"
   },
   "keywords": [
     "monorepo",

--- a/packages/odm-backend/package.json
+++ b/packages/odm-backend/package.json
@@ -1,12 +1,16 @@
 {
-  "name": "odm-backend",
+  "name": "mv-odm-backend",
   "version": "0.0.0",
   "description": "ODM Backend Package",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "odm",

--- a/packages/odm/package.json
+++ b/packages/odm/package.json
@@ -1,12 +1,16 @@
 {
-  "name": "odm",
+  "name": "mv-odm",
   "version": "0.0.0",
   "description": "ODM",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "odm",
@@ -15,7 +19,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "odm-backend": "0.0.0"
+    "mv-odm-backend": "0.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",


### PR DESCRIPTION
## Changes

This PR includes the following changes:

### Package Renaming
- Rename 'odm' package to 'mv-odm'
- Rename 'odm-backend' package to 'mv-odm-backend'
- Update all workspace references and dependencies accordingly

### Publishing Configuration
- Add publish script to root package.json for building and publishing both packages
- Add 'files' field to package.json files to specify what gets published
- Add 'prepublishOnly' scripts to ensure packages are built before publishing
- Update build script to use new package names

### Files Modified
- `package.json` - Added publish script and updated workspace references
- `packages/odm/package.json` - Renamed to mv-odm, added publishing config
- `packages/odm-backend/package.json` - Renamed to mv-odm-backend, added publishing config

These changes prepare the packages for npm publishing with proper naming conventions and build processes.